### PR TITLE
Update setup-python version in examples

### DIFF
--- a/README.org
+++ b/README.org
@@ -47,7 +47,7 @@ And refference these action.yml
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v1
-        - uses: actions/setup-python@v1.1.1
+        - uses: actions/setup-python@v2
           with:
             python-version: '3.6'
             architecture: 'x64'
@@ -86,7 +86,7 @@ This example is testing your package in below environment.
             - 'snapshot'
       steps:
         - uses: actions/checkout@v1
-        - uses: actions/setup-python@v1.1.1
+        - uses: actions/setup-python@v2
           with:
             python-version: '3.6'
             architecture: 'x64'
@@ -114,7 +114,7 @@ This example is testing your package in below environment.
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v1
-        - uses: actions/setup-python@v1.1.1
+        - uses: actions/setup-python@v2
         - uses: purcell/setup-emacs@master
           with:
             version: '26.3'


### PR DESCRIPTION
GitHub has deprecated set-env: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and setup-python 1.1.1 uses it.

This means that new repos using these instructions will error. Update the version so it works on new repos.