### PR TITLE
Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'snapshot'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
Hi!

Currently this actions shows a warning about the node version:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: conao3/setup-cask@master. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

I'm not familiar with the code of this action so maybe this change is too simplistic, but what I can say is that I pointed a package I maintain to my fork and it worked fine (and the warning is no longer there): https://github.com/porras/evil-ruby-text-objects/actions/runs/8646977431